### PR TITLE
misspelled variable name tempsum, and perimeter -> vals.perimeter

### DIFF
--- a/src/PolygonArea.js
+++ b/src/PolygonArea.js
@@ -275,7 +275,7 @@
    * @description A new vertex is *not* added to the polygon.
    */
   p.PolygonArea.prototype.TestEdge = function(azi, s, reverse, sign) {
-    var vals = {number: this.num ? this.num + 1 : 0}, t, tempsump, crossings;
+    var vals = {number: this.num ? this.num + 1 : 0}, t, tempsum, crossings;
     if (this.num === 0)
       return vals;
     vals.perimeter = this._perimetersum.Sum() + s;
@@ -288,7 +288,7 @@
     tempsum += t.S12;
     crossings += transitdirect(this.lon, t.lon2);
     t = this._geod(t.lat2, t.lon2, this._lat0, this._lon0, this._mask);
-    perimeter += t.s12;
+    vals.perimeter += t.s12;
     tempsum += t.S12;
     crossings += transit(t.lon2, this._lon0);
 


### PR DESCRIPTION
ps - I couldn't find a script to generate the built version. 